### PR TITLE
Added UHD support for 2x2 MIMO sounding

### DIFF
--- a/CC/Sounder/BaseRadioSet.cc
+++ b/CC/Sounder/BaseRadioSet.cc
@@ -209,7 +209,7 @@ BaseRadioSet::BaseRadioSet(Config* cfg)
                 bsRadios[0][i]->activateXmit();
                 dev->setHardwareTime(0, "TRIGGER");
             } else {
-                dev->setHardwareTime(0.0); // "CMD"
+                dev->setHardwareTime(0); // "CMD"
                 bsRadios[0][i]->activateRecv();
                 bsRadios[0][i]->activateXmit();
             }

--- a/CC/Sounder/BaseRadioSet.cc
+++ b/CC/Sounder/BaseRadioSet.cc
@@ -209,7 +209,7 @@ BaseRadioSet::BaseRadioSet(Config* cfg)
                 bsRadios[0][i]->activateXmit();
                 dev->setHardwareTime(0, "TRIGGER");
             } else {
-                dev->setHardwareTime(0); // "CMD"
+                dev->setHardwareTime(0, "UNKNOWN_PPS"); // "CMD"
                 bsRadios[0][i]->activateRecv();
                 bsRadios[0][i]->activateXmit();
             }

--- a/CC/Sounder/ClientRadioSet.cc
+++ b/CC/Sounder/ClientRadioSet.cc
@@ -138,7 +138,7 @@ ClientRadioSet::ClientRadioSet(Config* cfg)
                     radios[i]->activateXmit();
                     dev->writeSetting("TRIGGER_GEN", "");
                 } else {
-                    dev->setHardwareTime(0.0); // "CMD"
+                    dev->setHardwareTime(0); // "CMD"
                     radios[i]->activateRecv();
                     radios[i]->activateXmit();
                 }

--- a/CC/Sounder/ClientRadioSet.cc
+++ b/CC/Sounder/ClientRadioSet.cc
@@ -138,7 +138,7 @@ ClientRadioSet::ClientRadioSet(Config* cfg)
                     radios[i]->activateXmit();
                     dev->writeSetting("TRIGGER_GEN", "");
                 } else {
-                    dev->setHardwareTime(0); // "CMD"
+                    dev->setHardwareTime(0, "UNKNOWN_PPS"); // "CMD"
                     radios[i]->activateRecv();
                     radios[i]->activateXmit();
                 }

--- a/CC/Sounder/config.cc
+++ b/CC/Sounder/config.cc
@@ -140,7 +140,7 @@ Config::Config(const std::string& jsonfile)
         clDataMod = tddConfCl.value("modulation", "QPSK");
         frame_mode = tddConfCl.value("frame_mode", "continuous_resync");
         hw_framer = tddConfCl.value("hw_framer", true);
-        txAdvance = tddConfCl.value("tx_advance", kUseUHD ? 0 : 250); // 250
+        txAdvance = tddConfCl.value("tx_advance", kUseUHD ? 100 : 250); // 250
 
         auto jClTxgainA_vec = tddConfCl.value("txgainA", json::array());
         clTxgain_vec[0].assign(jClTxgainA_vec.begin(), jClTxgainA_vec.end());
@@ -440,14 +440,4 @@ unsigned Config::getCoreCount()
     std::cout << "number of CPU cores " << std::to_string(nCores) << std::endl;
 #endif
     return nCores;
-}
-
-extern "C"
-{
-    __attribute__((visibility("default"))) Config* Config_new(char *filename) {
-
-        Config *cfg = new Config(filename);
-
-        return cfg;
-    }
 }

--- a/CC/Sounder/config.cc
+++ b/CC/Sounder/config.cc
@@ -441,3 +441,13 @@ unsigned Config::getCoreCount()
 #endif
     return nCores;
 }
+
+extern "C"
+{
+    __attribute__((visibility("default"))) Config* Config_new(char *filename) {
+
+        Config *cfg = new Config(filename);
+
+        return cfg;
+    }
+}

--- a/CC/Sounder/config.cc
+++ b/CC/Sounder/config.cc
@@ -140,7 +140,7 @@ Config::Config(const std::string& jsonfile)
         clDataMod = tddConfCl.value("modulation", "QPSK");
         frame_mode = tddConfCl.value("frame_mode", "continuous_resync");
         hw_framer = tddConfCl.value("hw_framer", true);
-        txAdvance = tddConfCl.value("tx_advance", kUseUHD ? 100 : 250); // 250
+        txAdvance = tddConfCl.value("tx_advance", 250); // 250
 
         auto jClTxgainA_vec = tddConfCl.value("txgainA", json::array());
         clTxgain_vec[0].assign(jClTxgainA_vec.begin(), jClTxgainA_vec.end());

--- a/CC/Sounder/config.cc
+++ b/CC/Sounder/config.cc
@@ -140,7 +140,7 @@ Config::Config(const std::string& jsonfile)
         clDataMod = tddConfCl.value("modulation", "QPSK");
         frame_mode = tddConfCl.value("frame_mode", "continuous_resync");
         hw_framer = tddConfCl.value("hw_framer", true);
-        txAdvance = tddConfCl.value("tx_advance", 250); // 250
+        txAdvance = tddConfCl.value("tx_advance", kUseUHD ? 0 : 250); // 250
 
         auto jClTxgainA_vec = tddConfCl.value("txgainA", json::array());
         clTxgain_vec[0].assign(jClTxgainA_vec.begin(), jClTxgainA_vec.end());

--- a/CC/Sounder/include/macros.h
+++ b/CC/Sounder/include/macros.h
@@ -7,6 +7,9 @@ static constexpr bool kUseUHD = true;
 static constexpr bool kUseUHD = false;
 #endif
 
+static constexpr size_t kStreamContinuous = 1;
+static constexpr size_t kStreamEndBurst = 2;
+
 #define DEBUG_PRINT 0
 #define DEBUG_RADIO 0
 #define DEBUG_PLOT 0
@@ -22,5 +25,6 @@ static constexpr bool kUseUHD = false;
 #define MAX_FRAME_INC 2000
 #define TIME_DELTA 40 //ms
 #define SETTLE_TIME_MS 1
+#define BEACON_INTERVAL 20 // frames
 
 #endif

--- a/CC/Sounder/receiver.cc
+++ b/CC/Sounder/receiver.cc
@@ -406,7 +406,6 @@ void Receiver::clientTxRx(int tid)
             int r = clientRadioSet_->radioTx(tid, txbuff.data(), NUM_SAMPS, 1, txTime);
             if (r == NUM_SAMPS)
                 txTime += 0x10000;
-            std::cout << "radioTx() called..." << std::endl;
         }
     }
 }

--- a/CC/Sounder/receiver.cc
+++ b/CC/Sounder/receiver.cc
@@ -256,7 +256,7 @@ void Receiver::loopRecv(int tid, int core_id, SampleBuffer* rx_buffer)
 
                 // only write received pilot into samp
                 // otherwise use syncrxbuffBs as a dummy buffer
-                if (config_->isPilot(frame_id, symbol_id))
+                if (config_->isPilot(frame_id, symbol_id) || config_->isData(frame_id, symbol_id))
                     r = baseRadioSet_->radioRx(it, samp, rxTimeBs);
                 else
                     r = baseRadioSet_->radioRx(it, syncrxbuffBs.data(), rxTimeBs);


### PR DESCRIPTION
Main changes:
- For BS operations (transmit beacon, receive pilot) on the host, removed the for loop that counts sf from 0 to 19. Instead, re-organized the code so that it follows more of the default structure where one symbol is read in each iteration.
- When calling radioTx at consecutive timestamps on UHD device (e.g., two consecutive pilot tx calls), the first radioTx call should be without END_BURST flag, and the last (second) radioTx call should be with END_BURST flag. This seems to be a major difference than Iris and needs to be accounted for.

Tested with two x310s (one client: 2 radios on one x310, one BS: 2 radios on another x310),

TODOs:
- txAdvance seems to be largely dependent on sampling rate
-- fixed, use txAdvance = 100 for bw of 20MHz
- For each x310, need to calibrate the timestamp offset between its 2 radios, and then set the pilot tx time correspondingly
-- fixed, set "UNKNOWN_PPS" for hardware time so that the 2 radios in a single x310 are fully synced